### PR TITLE
Improve search filter functionality

### DIFF
--- a/assets/ts/search.ts
+++ b/assets/ts/search.ts
@@ -76,7 +76,8 @@ class Search {
 
     private bindFilters() {
         Array.from(this.filterItems).forEach((el) => {
-            el.addEventListener('click', () => {
+            el.addEventListener('click', (e) => {
+                el.parentElement.dataset.mode = e.ctrlKey ? 'i':'x';
                 this.filterSelect(el)
             })
         })
@@ -149,13 +150,30 @@ class Search {
 
     private filterSelect(el: HTMLElement) {
         let value = el.dataset.value;
+        let mode = el.parentElement.dataset.mode; // x or i
+        console.log(`filter mode is ${mode}`);
         let type = el.dataset.type;
-        if (el.classList.contains('active')) {
-            this.searchFilter.delete(value);
-            el.classList.remove('active');
+
+        // following selects only the selected element exclusively
+        if(mode === 'x') {
+          // clear the search filter.
+          this.searchFilter.clear();
+          // clear all selections
+          Array.from(this.filterItems).forEach((e) => { e.classList.remove('active'); });
+          // add new selection
+          el.classList.add('active');
+          // add new exclusive search filter
+          this.searchFilter.set(value, type);
+          console.log(this.searchFilter);
         } else {
-            this.searchFilter.set(value, type);
-            el.classList.add('active');
+          // following only toggles the selection for clicked element
+          if (el.classList.contains('active')) {
+              this.searchFilter.delete(value);
+              el.classList.remove('active');
+          } else {
+              this.searchFilter.set(value, type);
+              el.classList.add('active');
+          }
         }
         this.executeSearch(this.buildSearchValue(""));
     }

--- a/layouts/_default/archives.html
+++ b/layouts/_default/archives.html
@@ -11,7 +11,7 @@
 
 <section>
     <div class="container">
-        <div class="filter-container">
+      <div class="filter-container" data-mode="x"> <!-- x or i (exclusive, or combined) -->
           {{ $maxCategoryToShow := $.Site.Params.maxCategoryToShow | default 5 }}
           {{ range .Site.Taxonomies.categories.TaxonomyArray | first $maxCategoryToShow }}
             <div class="filter-item" data-value="{{ .Page.Title }}" data-type="categories">


### PR DESCRIPTION
With this change, the search filter included in the archives.html template defaults to exclusively the category clicked instead of a combination with previously selected category and offers a way to multi-select by holding down the CTRL key if multiple selection is required. Since the CTRL key behaviour is pretty standard across UIs, *no tips or manual is provided, as it is expected behaviour with selections.

*NOTE:
  - a tip can be added
  - a UI element indicating the current selection mode can be added to visually show clearly what is the current selection mode